### PR TITLE
Add fix for unity-ui theme

### DIFF
--- a/styles/multirow-tabs.less
+++ b/styles/multirow-tabs.less
@@ -11,3 +11,13 @@
     flex-basis: auto;
   }
 }
+
+.theme-unity-ui {
+  .multirow-tabs.tab-bar {
+    display: flex;
+    .tab {
+      flex-basis: 175px;
+      max-width: none;
+    }
+  }
+}


### PR DESCRIPTION
The Unity theme sets display to "table" and sets a max width of the tabs to 175.

Tested by putting this in my `styles.less`.
